### PR TITLE
Xbox series xs mappings

### DIFF
--- a/config/xbox_xs.config.yaml
+++ b/config/xbox_xs.config.yaml
@@ -1,0 +1,53 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    # Axis Mappings
+    # Left Stick Up/Down -> Linear Velocity (Forward/Backward)
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: -0.5       # Invert axis so UP is positive, and scale to 50% speed
+    scale_linear_turbo:
+      x: -1.0       # Invert axis and use 100% speed for turbo
+
+    # Left Stick Left/Right -> Angular Velocity (Turning)
+    axis_angular:
+      yaw: 0
+    scale_angular:
+      yaw: -0.8     # Invert axis so RIGHT is a negative rotation, scale to 80%
+    scale_angular_turbo:
+      yaw: -1.5     # Invert and allow for faster turning in turbo mode
+
+    # Button Mappings
+    # Use Left Bumper as the "dead man's switch"
+    enable_button: 9        # Left Bumper (LB)
+    # Use Right Bumper for "turbo" mode
+    enable_turbo_button: 10 # Right Bumper (RB)
+
+# Xbox XS Controller Button/Axis Reference:
+# ==========================================
+# 
+# Axes:
+#   axes[0] -> Left Thumbstick (horizontal)
+#   axes[1] -> Left Thumbstick (vertical)
+#   axes[2] -> Right Thumbstick (horizontal)
+#   axes[3] -> Right Thumbstick (vertical)
+#   axes[4] -> Left Trigger (LT)
+#   axes[5] -> Right Trigger (RT)
+#
+# Buttons:
+#   button 0  -> A
+#   button 1  -> B
+#   button 2  -> X
+#   button 3  -> Y
+#   button 4  -> Double window/rectangle button
+#   button 5  -> Xbox button
+#   button 6  -> 3 horizontal lines button
+#   button 7  -> Left joystick press
+#   button 8  -> Right joystick press
+#   button 9  -> L bumper
+#   button 10 -> R bumper
+#   button 11 -> Up arrow
+#   button 12 -> Down arrow
+#   button 13 -> Left arrow
+#   button 14 -> Right arrow
+#   button 15 -> Share button

--- a/config/xbox_xs.config.yaml
+++ b/config/xbox_xs.config.yaml
@@ -5,17 +5,17 @@ teleop_twist_joy_node:
     axis_linear:
       x: 1
     scale_linear:
-      x: -0.5       # Invert axis so UP is positive, and scale to 50% speed
+      x: 0.3       # Invert axis so UP is positive, and scale to 50% speed
     scale_linear_turbo:
-      x: -1.0       # Invert axis and use 100% speed for turbo
+      x: 1.0       # Invert axis and use 100% speed for turbo
 
     # Left Stick Left/Right -> Angular Velocity (Turning)
     axis_angular:
       yaw: 0
     scale_angular:
-      yaw: -0.8     # Invert axis so RIGHT is a negative rotation, scale to 80%
+      yaw: 0.4     # Invert axis so RIGHT is a negative rotation, scale to 80%
     scale_angular_turbo:
-      yaw: -1.5     # Invert and allow for faster turning in turbo mode
+      yaw: 1.0     # Invert and allow for faster turning in turbo mode
 
     # Button Mappings
     # Use Left Bumper as the "dead man's switch"

--- a/launch/teleop-launch.py
+++ b/launch/teleop-launch.py
@@ -3,6 +3,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 import launch
+import launch.conditions
 import launch_ros.actions
 
 
@@ -10,17 +11,32 @@ def generate_launch_description():
     joy_config = launch.substitutions.LaunchConfiguration('joy_config')
     joy_dev = launch.substitutions.LaunchConfiguration('joy_dev')
     config_filepath = launch.substitutions.LaunchConfiguration('config_filepath')
+    use_joy_node = launch.substitutions.LaunchConfiguration('use_joy_node')
 
     return launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument('joy_vel', default_value='mux/cmd_vel'),
         launch.actions.DeclareLaunchArgument('joy_config', default_value='xbox'),
         launch.actions.DeclareLaunchArgument('joy_dev', default_value='/dev/input/js0'),
+        launch.actions.DeclareLaunchArgument('use_joy_node', default_value='false',
+            description='Whether to launch the joy_node locally (true) or use remote joy_node (false)'),
         launch.actions.DeclareLaunchArgument('config_filepath', default_value=[
             launch.substitutions.TextSubstitution(text=os.path.join(
                 get_package_share_directory('teleop_twist_joy'), 'config', '')),
             joy_config, launch.substitutions.TextSubstitution(text='.config.yaml')]),
 
+        # Joy node to read from joystick device and publish to /joy topic (optional)
+        launch.actions.GroupAction([
+            launch_ros.actions.Node(
+                package='joy', executable='joy_node',
+                name='joy_node', parameters=[{
+                    'dev': joy_dev,
+                    'deadzone': 0.3,
+                    'autorepeat_rate': 20.0,
+                }],
+                ),
+        ], condition=launch.conditions.IfCondition(use_joy_node)),
         
+        # Teleop node to convert joystick data to velocity commands
         launch_ros.actions.Node(
             package='teleop_twist_joy', executable='teleop_node',
             name='teleop_twist_joy_node', parameters=[config_filepath],


### PR DESCRIPTION
From testing with the new XS controller with latest firmware, the button/axes mappings seem slightly changed. This adds a new config and an optional joy node to connect a joy directly to the robot.

Note: 
- This adds a dependency to ros-humble-joy and joystick installable through apt
- launch command option use_joy_node:=true
- launch command option joy_config:=xbox_xs